### PR TITLE
reschedule update even if error occured

### DIFF
--- a/mmm-hue-lights.js
+++ b/mmm-hue-lights.js
@@ -611,12 +611,11 @@ Module.register('mmm-hue-lights', {
 
         if (notification === 'MMM_HUE_LIGHTS_DATA') {
             self.processHueData(payload);
-            self.scheduleUpdate(self.config.updateInterval);
         } else if (notification === 'MMM_HUE_LIGHTS_DATA_ERROR') {
             self.errMsg = payload;
             self.updateDom(self.config.animationSpeed);
         }
-
+        self.scheduleUpdate(self.config.updateInterval);
     },
 
     suspend: function() {


### PR DESCRIPTION
My mirror had a problem connecting to the hue bridge. Once that happens your code does not reschedule an update, so the mirror will not recover from the error. 
I changed the code so that an update is rescheduled independently of the result received.