### PR TITLE
2.0.0: Replace request with Axios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Temporary Items
 .fuse_hidden*
 .directory
 .Trash-*
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Please note that this module still uses v1 of the Hue API - once v2 of the Hue A
 
 
 ## Installing the module
-Run `git clone https://github.com/michael5r/mmm-hue-lights.git` from inside your `MagicMirror/modules` folder.
+1. Run `git clone https://github.com/michael5r/mmm-hue-lights.git` from inside your `MagicMirror/modules` folder.
+2. Enter the new `mmm-hue-lights` directory and execute `npm install`.
 
 
 ## Getting the Hue credentials

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This module requires MagicMirror version `2.5` or later.
 
 This module displays the status of your [Philips Hue](http://meethue.com) lights and light groups on your Magic Mirror and and supports multiple view types and modes.
 
+Please note that this module still uses v1 of the Hue API - once v2 of the Hue API has been released, I'll get the module updated.  
+
 ![image](https://user-images.githubusercontent.com/3209660/49979103-2e3cd400-ff13-11e8-8f76-bc4c7d5e7b76.png)
 
 *An example showing light groups on the left and lights on the right in the Grid view.*
@@ -41,7 +43,7 @@ In order for you to have access to your Hue lights, you need a [Hue developer ac
 
 Please follow the instructions on this page to get both:
 
-https://www.developers.meethue.com/documentation/getting-started
+https://developers.meethue.com/develop/get-started-2/
 
 If you don't have a Hue developer account already, click the `register` link on the page above to set one up (it's free).
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,5 @@
-var NodeHelper = require('node_helper');
-var request = require('request');
+var NodeHelper = require("node_helper");
+var axios = require('axios').default;
 
 module.exports = NodeHelper.create({
 
@@ -17,20 +17,21 @@ module.exports = NodeHelper.create({
             var url = 'http://' + bridgeIp + '/api/' + user;
             var self = this;
 
-            request(url, {method: 'GET'}, function(err, res, body) {
-
-                if ((err) || (res.statusCode !== 200)) {
-                    self.sendSocketNotification('MMM_HUE_LIGHTS_DATA_ERROR', 'Hue API Error: ' + err);
-                } else {
-                    if (body === {}) {
-                        self.sendSocketNotification('MMM_HUE_LIGHTS_DATA_ERROR', 'Hue API Error: No Hue data was received.');
+            axios.get(url)
+                .then(function (res) {
+                    if (res.status !== 200) {
+                        self.sendSocketNotification('MMM_HUE_LIGHTS_DATA_ERROR', 'Hue API Error: ' + res.status);
                     } else {
-                        var data = JSON.parse(body);
-                        self.sendSocketNotification('MMM_HUE_LIGHTS_DATA', data);
+                        if (res.data === {}) {
+                            self.sendSocketNotification('MMM_HUE_LIGHTS_DATA_ERROR', 'Hue API Error: No Hue data was received.');
+                        } else {
+                            self.sendSocketNotification('MMM_HUE_LIGHTS_DATA', res.data);
+                        }
                     }
-                }
-
-            });
+                })
+                .catch(function (err) {
+                    self.sendSocketNotification('MMM_HUE_LIGHTS_DATA_ERROR', 'Hue API Error: ' + err);
+                });
 
         }
     }

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,4 +1,4 @@
-var NodeHelper = require("node_helper");
+var NodeHelper = require('node_helper');
 var axios = require('axios').default;
 
 module.exports = NodeHelper.create({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "mmm-hue-lights",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mmm-hue-lights",
+  "version": "2.0.0",
+  "description": "Display the status of your Philips Hue lights and light groups on your MagicMirror. Supports multiple view types and modes.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/michael5r/mmm-hue-lights"
+  },
+  "main": "mmm-hue-lights.js",
+  "scripts": {
+    "test": "echo \"Error: No tests specified\" && exit 1"
+  },
+  "author": "Michael Schmidt",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.26.0"
+  }
+}


### PR DESCRIPTION
As the title says - MagicMirror removed `request` as a dependency, so this module would fail in newer MM installs.
Also updated the read me.